### PR TITLE
Update README to add INT and DATE encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The following are the types for `encodings` are supported provided as static pro
 - `IndexEncoder.BUFFER` : Encodes a buffer.
 - `IndexEncoder.STRING` : Encodes a string.
 - `IndexEncoder.UINT` : Encodes an unsigned integer.
+- `IndexEncoder.INT` : Encodes an signed integer.
+- `IndexEncoder.DATE` : Encodes a date.
 - `IndexEncoder.BOOL` : Encodes a boolean.
 
 #### `const enc = IndexEncoder.lookup(c)`


### PR DESCRIPTION
Add descriptions for IndexEncoder.INT and IndexEncoder.DATE.